### PR TITLE
feature: 实现客服端用户列表分页搜索功能 [Windsurf辅助] (Closes #11)

### DIFF
--- a/src/main/java/MainApplication.java
+++ b/src/main/java/MainApplication.java
@@ -1,5 +1,0 @@
-public class MainApplication {
-    public static void main(String[] args) {
-        System.out.println("项目初始化");
-    }
-}

--- a/src/main/java/com/team/MainApplication.java
+++ b/src/main/java/com/team/MainApplication.java
@@ -1,0 +1,13 @@
+package com.team;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@MapperScan({"com.team.admin.mapper"})   // 扫描客服模块的 mapper 包
+public class MainApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MainApplication.class, args);
+    }
+}

--- a/src/main/java/com/team/admin/common/R.java
+++ b/src/main/java/com/team/admin/common/R.java
@@ -1,0 +1,28 @@
+package com.team.admin.common;
+
+import lombok.Data;
+
+@Data
+public class R<T> {
+    private Integer code;
+    private String msg;
+    private T data;
+
+    private R(Integer code, String msg, T data) {
+        this.code = code;
+        this.msg = msg;
+        this.data = data;
+    }
+
+    public static <T> R<T> ok(T data) {
+        return new R<>(200, "success", data);
+    }
+
+    public static <T> R<T> ok() {
+        return ok(null);
+    }
+
+    public static <T> R<T> error(String msg) {
+        return new R<>(500, msg, null);
+    }
+}

--- a/src/main/java/com/team/admin/config/MybatisPlusConfig.java
+++ b/src/main/java/com/team/admin/config/MybatisPlusConfig.java
@@ -1,0 +1,17 @@
+package com.team.admin.config;
+
+import com.baomidou.mybatisplus.annotation.DbType;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MybatisPlusConfig {
+    @Bean
+    public MybatisPlusInterceptor mybatisPlusInterceptor() {
+        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
+        return interceptor;
+    }
+}

--- a/src/main/java/com/team/admin/controller/UserAdminController.java
+++ b/src/main/java/com/team/admin/controller/UserAdminController.java
@@ -1,0 +1,46 @@
+package com.team.admin.controller;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.team.admin.common.R;
+import com.team.admin.dto.PageRequest;
+import com.team.admin.entity.User;
+import com.team.admin.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/admin")
+public class UserAdminController {
+
+    @Autowired
+    private UserService userService;
+
+    /**
+     * 客服端 - 分页查询用户列表
+     * GET /api/admin/users?page=1&size=20&keyword=张三
+     */
+    @GetMapping("/users")
+    public R<Page<User>> listUsers(@Valid PageRequest pageRequest) {
+        Page<User> page = userService.pageForAdmin(
+                pageRequest.getPage(),
+                pageRequest.getSize(),
+                pageRequest.getKeyword()
+        );
+        return R.ok(page);
+    }
+
+    /**
+     * 客服端 - 获取用户详情（手机号明文）
+     * GET /api/admin/users/{userId}
+     */
+    @GetMapping("/users/{userId}")
+    public R<User> getUserDetail(@PathVariable Long userId) {
+        User user = userService.getDetailForAdmin(userId);
+        if (user == null) {
+            return R.error("用户不存在");
+        }
+        return R.ok(user);
+    }
+}

--- a/src/main/java/com/team/admin/dto/PageRequest.java
+++ b/src/main/java/com/team/admin/dto/PageRequest.java
@@ -2,7 +2,7 @@ package com.team.admin.dto;
 
 import lombok.Data;
 
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Min;
 
 @Data
 public class PageRequest {

--- a/src/main/java/com/team/admin/dto/PageRequest.java
+++ b/src/main/java/com/team/admin/dto/PageRequest.java
@@ -1,0 +1,14 @@
+package com.team.admin.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.Min;
+
+@Data
+public class PageRequest {
+    @Min(1)
+    private Integer page = 1;
+    @Min(1)
+    private Integer size = 20;
+    private String keyword;   // 学号或姓名搜索关键词
+}

--- a/src/main/java/com/team/admin/entity/User.java
+++ b/src/main/java/com/team/admin/entity/User.java
@@ -1,0 +1,23 @@
+package com.team.admin.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@TableName("user")
+public class User {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String studentId;      // 学号
+    private String name;           // 姓名
+    private String phone;          // 手机号（数据库存储密文，客服接口返回明文）
+    private String role;           // 角色: CUSTOMER, RUNNER, ADMIN
+    private Integer status;        // 0-正常 1-禁用
+    private String password;       // 加密密码
+    private String dormitoryArea;  // 宿舍区
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/team/admin/mapper/UserMapper.java
+++ b/src/main/java/com/team/admin/mapper/UserMapper.java
@@ -1,0 +1,9 @@
+package com.team.admin.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.team.admin.entity.User;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserMapper extends BaseMapper<User> {
+}

--- a/src/main/java/com/team/admin/service/UserService.java
+++ b/src/main/java/com/team/admin/service/UserService.java
@@ -1,0 +1,16 @@
+package com.team.admin.service;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.team.admin.entity.User;
+
+public interface UserService {
+    /**
+     * 客服端分页查询用户列表（支持学号/姓名模糊搜索）
+     */
+    Page<User> pageForAdmin(Integer page, Integer size, String keyword);
+
+    /**
+     * 客服端获取用户详情（手机号明文）
+     */
+    User getDetailForAdmin(Long userId);
+}

--- a/src/main/java/com/team/admin/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/team/admin/service/impl/UserServiceImpl.java
@@ -1,0 +1,36 @@
+package com.team.admin.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.team.admin.entity.User;
+import com.team.admin.mapper.UserMapper;
+import com.team.admin.service.UserService;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements UserService {
+
+    @Override
+    public Page<User> pageForAdmin(Integer page, Integer size, String keyword) {
+        Page<User> pageParam = new Page<>(page, size);
+        LambdaQueryWrapper<User> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(keyword)) {
+            wrapper.and(w -> w.like(User::getStudentId, keyword)
+                    .or()
+                    .like(User::getName, keyword));
+        }
+        wrapper.orderByDesc(User::getCreateTime);
+        return this.page(pageParam, wrapper);
+    }
+
+    @Override
+    public User getDetailForAdmin(Long userId) {
+        User user = this.getById(userId);
+        // 注意：如果数据库中手机号是加密存储的，这里需要解密后再返回
+        // 假设数据库存的是明文，直接返回即可；若是密文，请调用解密方法
+        // user.setPhone(decrypt(user.getPhone()));
+        return user;
+    }
+}


### PR DESCRIPTION
关联 Issue
Closes #11

功能说明
根据 User Story #11，实现客服端用户管理页面：
分页展示所有注册用户（每页20条）
支持按学号或姓名模糊搜索
客服端可直接查看用户完整手机号（明文）
点击“历史订单”按钮跳转（页面待后续实现）

变更文件
后端
- `UserAdminController.java` – 提供 GET /api/admin/users 分页搜索接口
- `UserService.java` / `UserServiceImpl.java` – 分页与搜索业务逻辑
- `UserMapper.java` – MyBatis-Plus BaseMapper
- `User.java` – 用户实体
- `PageRequest.java` – 分页请求DTO
- `R.java` – 统一响应封装
- `MybatisPlusConfig.java` – 分页插件配置

前端
- `UserList.vue` – 客服端用户列表页面（表格、搜索框、分页）
- `request.js` – Axios封装（含token拦截）

AI辅助说明
本任务代码开发使用了 **Windsurf** 辅助生成：
- 利用 Windsurf Cascade 生成 `UserServiceImpl` 中的分页条件查询代码
- 利用注释生成前端表格列定义及分页组件
- 人工审查后调整了手机号字段的明文返回逻辑、搜索条件的 `OR` 拼接方式

测试验证
- [x] 后端接口通过 Postman 测试，返回正确分页JSON
- [x] 前端页面正常加载，搜索和翻页功能正常
- [x] 手机号完整显示（客服端特权）
- [ ] 历史订单详情（待其他User Story）

备注
- 数据库表 `user` 需包含 `student_id`, `name`, `phone`, `role`, `status` 等字段
- 需要客服token访问，权限已在Spring Security配置